### PR TITLE
Fix JavaDoc

### DIFF
--- a/app/src/main/java/Character/Forge/Behavior/DataLoader.java
+++ b/app/src/main/java/Character/Forge/Behavior/DataLoader.java
@@ -51,6 +51,11 @@ public class DataLoader {
 
     private DataLoader() {}
 
+    /**
+     * Access singleton DataLoader object
+     * <p>
+     * @return DataLoader
+     */
     public static DataLoader getDataLoaderInstance() {
         if (dataLoaderInstance == null) {
             dataLoaderInstance = new DataLoader();

--- a/app/src/main/java/Character/Forge/Behavior/IOManager.java
+++ b/app/src/main/java/Character/Forge/Behavior/IOManager.java
@@ -36,8 +36,8 @@ import lombok.extern.log4j.Log4j2;
  * from json files stored at src/main/resources/serialized-objects/[file].json
  * <p>
  * Uses generic typing to serialize and deserialize different data-class types, meaning
- * a new IOManager<[object type]> will be required for each type of object being serialized. A small
- * price to pay for not needing to write 21 separate read, write, and append methods.
+ * a new IOManager will be required for each type of object being serialized. A small
+ * price to pay for not needing to write 21 separate read, write, and append methods though.
  * <p>
  * @version 0.2.1
  * @author Noah Owens
@@ -59,8 +59,7 @@ public class IOManager<T> {
     private BufferedReader reader;
 
     /**
-     * Constructor binds T to a type at runtime to circumvent type erasure. Use like:
-     * Executor<[myClass]> ioManager = new IOManager<[myClass]>(new TypeToken<ArrayList<[myClass]>>() {})
+     * Constructor binds T to a type at runtime to circumvent type erasure.
      * Read why this works at https://stackoverflow.com/a/14506181
      * <p>
      * @param listType new TypeToken
@@ -100,6 +99,7 @@ public class IOManager<T> {
     /**
      * Deserialize ArrayList from file, use add method to append list, then reserialize.
      * <p>
+     * @param objList ArrayList of type T with any number of T objects in it
      * @param filePath string location of file, typically src/main/resources/serialized-objects/[fileName].json
      */
     public void appendFile(ArrayList<T> objList, String filePath) {
@@ -114,6 +114,11 @@ public class IOManager<T> {
         }
     }
 
+    /**
+     * Deserialize ArrayList from json
+     * @param filePath String location of the file, typically src/main/resources/serialized-objects/[fileName].json
+     * @return ArrayList of type T read from file
+     */
     public ArrayList<T> jsonRead(String filePath) {
         File file = new File(filePath);
         ArrayList<T> listFromJson = new ArrayList<>();

--- a/app/src/main/java/Character/Forge/Behavior/PlayerCharacter.java
+++ b/app/src/main/java/Character/Forge/Behavior/PlayerCharacter.java
@@ -56,7 +56,7 @@ public class PlayerCharacter {
      * PlayerCharacter constructor instantiates an ArrayList named "equipment" for storing adventuring paraphernalia and likewise one for "spells"
      * <p>
      * @param name the character's given name
-     * @param level an integer between 1 & 20 representative of the character's power
+     * @param level an integer between 1 and 20 representative of the character's power
      * @param charClass the character's profession, expertise, or proclivity (warlock, fighter, cleric, etc.)
      * @param race the character's species (human, goblin, dwarf, etc.)
      * @param hp an integer representing a character's health points.

--- a/app/src/main/java/Character/Forge/Behavior/RandomHelper.java
+++ b/app/src/main/java/Character/Forge/Behavior/RandomHelper.java
@@ -44,7 +44,7 @@ public class RandomHelper {
      * Simulate the roll of a die with n sides.
      * <p>
      * @param n the number of sides
-     * @return an integer value between [1 & n] inclusive both sides
+     * @return an integer value between [1, n] inclusive both sides
      * @throws IllegalArgumentException if passed a negative n
      */
     public int rollDie(int n) throws IllegalArgumentException {
@@ -55,8 +55,9 @@ public class RandomHelper {
      * Create random number between [0,n) inclusive of zero only
      * @param n upper bound (non-inclusive)
      * @return a number between [0,n)
+     * @throws IllegalArgumentException if passed a negative n
      */
-    public int randNum(int n) {
+    public int randNum(int n) throws IllegalArgumentException {
         return r.nextInt(n);
     }
 }

--- a/app/src/main/java/Character/Forge/Data/Stat.java
+++ b/app/src/main/java/Character/Forge/Data/Stat.java
@@ -28,7 +28,7 @@ import lombok.Setter;
 
 /**
  * Stat class creates a specific [name, value] pair object to represent the 6 main stats
- * plus Hp of a 5e D&D character
+ * plus Hp of a 5e DnD character
  * <p>
  * @version v0.1.0
  * @author Noah Owens
@@ -42,7 +42,7 @@ public class Stat {
      * Stat constructor creates an object with an id that can be easily parsed for it's raw value and it's applied bonus for skill checks
      * <p>
      * @param id the 2-3 character representation of the stat (Hp, STR, WIS, CHA, etc.)
-     * @param value the raw number (between 3 & 20) value of the stat
+     * @param value the raw number (between 3 and 20) value of the stat
      * @param bonus the number derived from the raw value which is applied to skill checks
      */
     public Stat(String id, int value, int bonus) {


### PR DESCRIPTION
# Fix JavaDoc Errors

## Description
Various ampersands and angle-brackets were scattered throughout the JavaDoc commenting in the project. Running ```gradle javadoc``` now succeeds, since all the errors are gone, although there are still warnings about undocumented things. (For the moment I have decided to ignore that."

## Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
