### PR TITLE
Stat Bonus Setter

### DIFF
--- a/app/src/main/java/Character/Forge/Behavior/PlayerCharacter.java
+++ b/app/src/main/java/Character/Forge/Behavior/PlayerCharacter.java
@@ -126,13 +126,7 @@ public class PlayerCharacter {
      * @return An arraylist of Stat objects with size 6 which includes [str,dex,con,int,wis,cha] with populated value and bonus properties
      */
     public ArrayList<Stat> createStatsAndBonuses() {
-        ArrayList<Stat> finalStats = applyRacialStatChanges(generateStats());
-
-        for (Stat i : finalStats) {
-            i.setBonus(i.deriveBonus());
-        }
-
-        return finalStats;
+        return applyRacialStatChanges(generateStats());
     }
 
     /**

--- a/app/src/main/java/Character/Forge/Data/Stat.java
+++ b/app/src/main/java/Character/Forge/Data/Stat.java
@@ -24,7 +24,6 @@
 package Character.Forge.Data;
 
 import lombok.Getter;
-import lombok.Setter;
 
 /**
  * Stat class creates a specific [name, value] pair object to represent the 6 main stats
@@ -35,8 +34,8 @@ import lombok.Setter;
  */
 public class Stat {
     @Getter final private String id;
-    @Getter @Setter private int value;
-    @Getter @Setter private int bonus;
+    @Getter private int value;
+    @Getter private int bonus;
 
     /**
      * Stat constructor creates an object with an id that can be easily parsed for it's raw value and it's applied bonus for skill checks
@@ -52,11 +51,32 @@ public class Stat {
     }
 
     /**
+     * Value setter which automatically updates Stat.bonus to reflect the new Stat.value
+     * <p>
+     * @param v integer stat value
+     */
+    public void setValue(int v) {
+        value = v;
+
+        int b = deriveBonus();
+        setBonus(b);
+    }
+
+    /**
+     * Private value setter which is called from inside setValue()
+     * <p>
+     * @param b integer bonus value
+     */
+    private void setBonus(int b) {
+        bonus = b;
+    }
+
+    /**
      * Returns a bonus using the Player's Handbook calculation for ability modifiers
      * <p>
      * @return stat bonus derived from stat object's value field
      */
-    public int deriveBonus() {
+    private int deriveBonus() {
         double b = Math.floor((value - 10.0) / 2.0);
         return (int) b;
     }

--- a/app/src/main/java/Character/Forge/Data/Stat.java
+++ b/app/src/main/java/Character/Forge/Data/Stat.java
@@ -38,7 +38,7 @@ public class Stat {
     @Getter private int bonus;
 
     /**
-     * Stat constructor creates an object with an id that can be easily parsed for it's raw value and it's applied bonus for skill checks
+     * Stat constructor creates an obje ct with an id that can be easily parsed for it's raw value and it's applied bonus for skill checks
      * <p>
      * @param id the 2-3 character representation of the stat (Hp, STR, WIS, CHA, etc.)
      * @param value the raw number (between 3 and 20) value of the stat

--- a/app/src/test/java/Character/Forge/PlayerCharacterTest.java
+++ b/app/src/test/java/Character/Forge/PlayerCharacterTest.java
@@ -145,7 +145,6 @@ public class PlayerCharacterTest {
 
         // constitution set to a normal value/bonus pair manually for purposes of this test
         lyle.getStats().get(2).setValue(16);
-        lyle.getStats().get(2).setBonus(3);
 
         int adjustedHp = lyle.conAdjustHp(lyleHp);
 

--- a/app/src/test/java/Character/Forge/StatTest.java
+++ b/app/src/test/java/Character/Forge/StatTest.java
@@ -46,4 +46,10 @@ public class StatTest {
         strength = new Stat("STR", 14, 0);
         wisdom = new Stat("WIS", 7, 0);
     }
+
+    @Test
+    @DisplayName("toString() outputs a consistent, correct format")
+    public void testToString() {
+        assert (strength.toString().equals("Stat{" + "id='" + strength.getId() + '\'' + ", value=" + strength.getValue() + ", bonus=" + strength.getBonus() + '}'));
+    }
 }

--- a/app/src/test/java/Character/Forge/StatTest.java
+++ b/app/src/test/java/Character/Forge/StatTest.java
@@ -46,21 +46,4 @@ public class StatTest {
         strength = new Stat("STR", 14, 0);
         wisdom = new Stat("WIS", 7, 0);
     }
-
-    /**
-     * Tests the deriveBonus() method in Stat.java
-     */
-    @Test
-    @DisplayName("Test that derive bonus calculation is handled correctly.")
-    public void testDeriveBonus(){
-        strength.setBonus(strength.deriveBonus());
-        assert(strength.getBonus() == 2);
-
-        strength.setValue(18);
-        strength.setBonus(strength.deriveBonus());
-        assert(strength.getBonus() == 4);
-
-        wisdom.setBonus(wisdom.deriveBonus());
-        assert(wisdom.getBonus() == -2);
-    }
 }


### PR DESCRIPTION
# Streamline Value/Bonus Assignment for Stats

## Description
Closes #12 by creating a custom, public setter for Stat.value which sets the bonus to its derived value at the same time. Setter for Stat.bonus made private. 

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
